### PR TITLE
Update KSES list of allowed tags for donation context

### DIFF
--- a/includes/kses.php
+++ b/includes/kses.php
@@ -14,14 +14,49 @@ if ( ! function_exists( 'amnesty_donations_kses_allowed_html' ) ) {
 			return $tags;
 		}
 
+		$attributes = _wp_add_global_attributes(
+			[
+				'aria-role' => true,
+			]
+		);
+
 		return array_merge_recursive(
 			$tags,
 			[
-				'span'   => _wp_add_global_attributes( [] ),
-				'select' => _wp_add_global_attributes( [] ),
-				'option' => _wp_add_global_attributes( [] ),
-				'input'  => array_merge(
-					_wp_add_global_attributes( [] ),
+				'header'   => $attributes,
+				'div'      => $attributes,
+				'h2'       => $attributes,
+				'p'        => $attributes,
+				'a'        => $attributes,
+				'span'     => $attributes,
+				'fieldset' => $attributes,
+				'legend'   => $attributes,
+				'hr'       => [],
+				'select'   => $attributes,
+				'option'   => $attributes,
+				'form'     => array_merge(
+					$attributes,
+					[
+						'method' => true,
+						'action' => true,
+					],
+				),
+				'button'   => array_merge(
+					$attributes,
+					[
+						'type'           => true,
+						'aria-has-popup' => true,
+					],
+				),
+				'label'    => array_merge(
+					$attributes,
+					[
+						'for'      => true,
+						'tabindex' => true,
+					],
+				),
+				'input'    => array_merge(
+					$attributes,
 					[
 						'type'        => true,
 						'name'        => true,
@@ -31,9 +66,10 @@ if ( ! function_exists( 'amnesty_donations_kses_allowed_html' ) ) {
 						'step'        => true,
 						'placeholder' => true,
 						'disabled'    => true,
-					] 
+						'required'    => true,
+					],
 				),
-			] 
+			]
 		);
 	}
 }

--- a/private/src/style.scss
+++ b/private/src/style.scss
@@ -102,6 +102,10 @@
   color: #fff;
 }
 
+.donation-selectType input[type="radio"] {
+  display: none;
+}
+
 .donation-options {
   display: none;
   flex-direction: column;


### PR DESCRIPTION
The existing KSES setup was designed only for escaping output from within the block itself.
However, when escaping the whole of the block when output "manually" elsewhere, many of the required tags and attributes are stripped, resulting in a broken block.

This PR updates the list of KSES tags and attributes, to allow the whole block to be escaped without breaking it. 

**steps to test**:
1. insert a donation block into a post
2. programmatically retrieve the post content
3. parse the content into blocks
4. grab the donation block from the parsed blocks
5. call `render_block` on the donation block, and pass the output to `wp_kses_post`
6. the block will be broken
7. replace `wp_kses_post` with `wp_kses`, passing `'donations'` as the context
8. the block should function correctly
9. add some "malicious" code to the output before running it through `wp_kses`
10. the "malicious" code should still be stripped

example code:
```php
$content = get_post_field( 'post_content', 123 );
$blocks  = parse_blocks( $content );
$donates = array_filter( $blocks, fn ( $b ) => 'amnesty-wc/donation' === $b['name'] );
$donate  = array_values( $donates )[0];

$rendered = render_block( $donate );

// this will be broken (step 5)
echo wp_kses_post( $rendered );
// this should be fine (step 7)
echo wp_kses( $rendered, 'donations' );
// this should be fine (step 9)
echo wp_kses( $rendered . '<script>alert(1)</script>', 'donations' );
```