### PR TITLE
Migrate script localisation from theme

### DIFF
--- a/amnesty-donations.php
+++ b/amnesty-donations.php
@@ -268,6 +268,21 @@ class Init {
 
 		wp_enqueue_style( 'aidonations-style', plugins_url( '/assets/styles/app.css', __FILE__ ), [], $this->data['Version'], 'all' );
 		wp_enqueue_script( 'aidonations-app', plugins_url( '/assets/scripts/app.js', __FILE__ ), [], $this->data['Version'], true );
+
+		if ( ! current_theme_supports( 'woocommerce' ) ) {
+			return;
+		}
+
+		wp_localize_script(
+			'aidonations-app',
+			'amnestyWC',
+			[
+				'nonce'  => wp_create_nonce( 'amnesty-wc' ),
+				'wooccm' => amnesty_get_wooccm_fields(
+					fn ( $field ) => empty( $field['disabled'] ) && 'select' === $field['type'],
+				),
+			],
+		);
 	}
 
 	/**
@@ -279,6 +294,21 @@ class Init {
 		wp_enqueue_style( 'aidonations-style', plugins_url( '/assets/styles/app.css', __FILE__ ), [], $this->data['Version'], 'all' );
 		wp_enqueue_style( 'aidonations-editor', plugins_url( '/assets/styles/block.css', __FILE__ ), [ 'aidonations-style' ], $this->data['Version'], 'all' );
 		wp_enqueue_script( 'aidonations-editor', plugins_url( '/assets/scripts/block.js', __FILE__ ), [ 'lodash', 'wp-blocks', 'wc-settings' ], $this->data['Version'], true );
+
+		if ( ! current_theme_supports( 'woocommerce' ) ) {
+			return;
+		}
+
+		wp_localize_script(
+			'aidonations-editor',
+			'amnestyWC',
+			[
+				'nonce'  => wp_create_nonce( 'amnesty-wc' ),
+				'wooccm' => amnesty_get_wooccm_fields(
+					fn ( $field ) => empty( $field['disabled'] ) && 'select' === $field['type'],
+				),
+			],
+		);
 	}
 
 	/**


### PR DESCRIPTION
Ref https://github.com/amnestywebsite/humanity-theme/issues/285

As part of the Block API migration work taking place in the theme, the theme's script localisation work has been re-done. During that process, it was found that there were some values being localised against theme scripts that were actually external to the theme. These are therefore being migrated to their appropriate place. 

Steps to test:
1. on the theme, switch to [PR#551](https://github.com/amnestywebsite/humanity-theme/pull/551)
2. run a build
3. ensure you have WooCommerce Checkout Manager enabled
4. go to wp-admin -> woocommerce -> settings -> checkout -> additional
5. add a new field if there isn't one already existing
6. the field should be a select, and should have more than one option
7. note the field id (e.g. `additional_wooccm0`)
8. edit a post/page
9. insert a donation block
10. in the sidebar, there should be a panel labelled "Campaigns"
11. the panel should contain a dropdown labelled "Campaign options field"
12. the dropdown should contain the field you added in step 4 
13. when selecting that field from the dropdown, the block should render a dropdown containing the options you added to the field in step 4
