### PR TITLE
Fix campaigns dropdown output

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -100,10 +100,6 @@ if ( ! function_exists( 'amnesty_get_wooccm_field' ) ) {
 			return [];
 		}
 
-		if ( ! is_admin() ) {
-			$field_name = sprintf( 'additional_%s', $field_name );
-		}
-
 		$cache_key = sprintf( '%s-%s', __FUNCTION__, $field_name );
 		$cached    = wp_cache_get( $cache_key );
 
@@ -111,9 +107,7 @@ if ( ! function_exists( 'amnesty_get_wooccm_field' ) ) {
 			return $cached;
 		}
 
-		if ( is_admin() ) {
-			$fields = array_column( $fields, null, 'name' );
-		}
+		$fields = array_column( $fields, null, 'name' );
 
 		if ( ! isset( $fields[ $field_name ] ) ) {
 			return [];
@@ -185,19 +179,9 @@ if ( ! function_exists( 'amnesty_get_campaign_field_options' ) ) {
 			return [];
 		}
 
-		if ( is_admin() ) {
-			return array_filter(
-				array_map(
-					function ( $op ) {
-						return $op['label'];
-					},
-					$field['options']
-				),
-				$filter_callback
-			);
-		}
+		$options = array_map( fn ( array $option ): string => $option['label'], $field['options'] );
 
-		return array_filter( $field['options'], $filter_callback );
+		return array_filter( $options, $filter_callback );
 	}
 }
 


### PR DESCRIPTION
At some point, WooCommerce Checkout Manager updated its Additional Fields output. Unfortunately, we didn't catch this, and so campaigns output in the donation block on the frontend ceased to function.
This PR fixes the frontend output.

Steps to test:
1. ensure you have WooCommerce Checkout Manager enabled
2. go to wp-admin -> woocommerce -> settings -> checkout -> additional
3. add a new field if there isn't one already existing
4. the field should be a select, and should have more than one option
5. note the field id (e.g. `additional_wooccm0`)
6. edit a post/page
7. insert a donation block
8. in the sidebar, there should be a panel labelled "Campaigns"
9. the panel should contain a dropdown labelled "Campaign options field"
10. the dropdown should contain the field you added in step 4 
11. when selecting that field from the dropdown, the block should render a dropdown containing the options you added to the field in step 4
12. save, and view the frontend
13. the campaigns dropdown should render correctly within the block
14. choose a donation amount, and a campaign
15. click donate
16. you should be redirected to WooCommerce checkout
17. the additional field should render in the checkout form
18. your selected option should be pre-selected in the dropdown